### PR TITLE
Remove unused require

### DIFF
--- a/lib/health_monitor/providers/redis.rb
+++ b/lib/health_monitor/providers/redis.rb
@@ -1,5 +1,4 @@
 require 'health_monitor/providers/base'
-require 'redis/namespace'
 
 module HealthMonitor
   module Providers


### PR DESCRIPTION
Requirement of `redis/namespace` assumes that `redis-namespace` gem is installed alongside with `redis` gem. This might not be true in some cases.

This PR removes requirement of `redis/namespace,` because it's not used anyway.