### PR TITLE
Typo in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ By default, environment variables is `nil`, so if you'd want to include addition
 
 ```ruby
 HealthMonitor.configure do |config|
-  config.environmet_variables = {
+  config.environment_variables = {
     build_number: 'BUILD_NUMBER',
     git_sha: 'GIT_SHA'
   }

--- a/app/controllers/health_monitor/health_controller.rb
+++ b/app/controllers/health_monitor/health_controller.rb
@@ -10,9 +10,9 @@ module HealthMonitor
     def check
       res = HealthMonitor.check(request: request)
 
-      HealthMonitor.configuration.environmet_variables ||= {}
-      v = HealthMonitor.configuration.environmet_variables.merge(time: Time.now.to_s(:db))
-      env_vars = [environmet_variables: v]
+      HealthMonitor.configuration.environment_variables ||= {}
+      v = HealthMonitor.configuration.environment_variables.merge(time: Time.now.to_s(:db))
+      env_vars = [environment_variables: v]
       res[:results] = env_vars + res[:results]
 
       self.content_type = Mime[:json]

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -2,7 +2,7 @@ module HealthMonitor
   class Configuration
     PROVIDERS = [:cache, :database, :redis, :resque, :sidekiq].freeze
 
-    attr_accessor :error_callback, :basic_auth_credentials, :environmet_variables
+    attr_accessor :error_callback, :basic_auth_credentials, :environment_variables
     attr_reader :providers
 
     def initialize

--- a/spec/controllers/health_monitor/health_controller_spec.rb
+++ b/spec/controllers/health_monitor/health_controller_spec.rb
@@ -22,7 +22,7 @@ describe HealthMonitor::HealthController, :type => :controller do
     before do
       HealthMonitor.configure do |config|
         config.basic_auth_credentials = { username: username, password: password }
-        config.environmet_variables = nil
+        config.environment_variables = nil
       end
     end
 
@@ -39,7 +39,7 @@ describe HealthMonitor::HealthController, :type => :controller do
 
         expect(response).to be_ok
         expect(JSON.parse(response.body)).to eq([{
-          'environmet_variables' => { 'time' => '1990-01-01 00:00:00' }
+          'environment_variables' => { 'time' => '1990-01-01 00:00:00' }
         },
         {
           'database' => {
@@ -68,17 +68,17 @@ describe HealthMonitor::HealthController, :type => :controller do
     end
   end
 
-  describe 'environmet variables' do
-    let(:environmet_variables) { { build_number: '12', git_sha: 'example_sha' } }
+  describe 'environment variables' do
+    let(:environment_variables) { { build_number: '12', git_sha: 'example_sha' } }
 
     before do
       HealthMonitor.configure do |config|
         config.basic_auth_credentials = nil
-        config.environmet_variables = environmet_variables
+        config.environment_variables = environment_variables
       end
     end
 
-    context 'valid environmet variables synatx provided' do
+    context 'valid environment variables synatx provided' do
       it 'succesfully checks' do
         expect {
           get :check
@@ -88,7 +88,7 @@ describe HealthMonitor::HealthController, :type => :controller do
         expect(JSON.parse(response.body)).to eq(
           [
             {
-              'environmet_variables' => {
+              'environment_variables' => {
                 'build_number' => '12',
                 'git_sha' => 'example_sha',
                 'time' => '1990-01-01 00:00:00'
@@ -111,7 +111,7 @@ describe HealthMonitor::HealthController, :type => :controller do
     before do
       HealthMonitor.configure do |config|
         config.basic_auth_credentials = nil
-        config.environmet_variables = nil
+        config.environment_variables = nil
       end
     end
 
@@ -122,7 +122,7 @@ describe HealthMonitor::HealthController, :type => :controller do
 
       expect(response).to be_ok
       expect(JSON.parse(response.body)).to eq([{
-        'environmet_variables' => { 'time' => '1990-01-01 00:00:00' }
+        'environment_variables' => { 'time' => '1990-01-01 00:00:00' }
       },
       {
         'database' => {
@@ -145,7 +145,7 @@ describe HealthMonitor::HealthController, :type => :controller do
 
         expect(response).to be_error
         expect(JSON.parse(response.body)).to eq([{
-          'environmet_variables' => { 'time' => '1990-01-01 00:00:00' }
+          'environment_variables' => { 'time' => '1990-01-01 00:00:00' }
         },
         {
           'database' => {


### PR DESCRIPTION
Change environmet to environment

Could be a breaking change if someone has hard coded the spelling error
in a response parser.