### PR TITLE
fix json render

### DIFF
--- a/app/controllers/health_monitor/health_controller.rb
+++ b/app/controllers/health_monitor/health_controller.rb
@@ -14,7 +14,7 @@ module HealthMonitor
       respond_to do |format|
         format.html
         format.json do
-          render json: statuses
+          render json: statuses.to_json
         end
         format.xml do
           render xml: statuses

--- a/app/controllers/health_monitor/health_controller.rb
+++ b/app/controllers/health_monitor/health_controller.rb
@@ -17,7 +17,7 @@ module HealthMonitor
           render json: statuses.to_json
         end
         format.xml do
-          render xml: statuses
+          render xml: statuses.to_xml
         end
       end
     end


### PR DESCRIPTION
hey all, we're running into the following issue with serialization when rendering as json:

```
Completed 500 Internal Server Error in 1545ms (ActiveRecord: 2.6ms)

ArgumentError - wrong number of arguments (2 for 0):
  active_model_serializers (0.9.5) lib/action_controller/serialization.rb:95:in `build_json_serializer'
  active_model_serializers (0.9.5) lib/action_controller/serialization.rb:50:in `block (2 levels) in <module:Serialization>'
  actionpack (4.2.7.1) lib/action_controller/metal/renderers.rb:45:in `block in _render_to_body_with_renderer'
  /Users/talha.saifi/.rvm/rubies/ruby-2.2.5/lib/ruby/2.2.0/set.rb:283:in `each'
  actionpack (4.2.7.1) lib/action_controller/metal/renderers.rb:41:in `_render_to_body_with_renderer'
  actionpack (4.2.7.1) lib/action_controller/metal/renderers.rb:37:in `render_to_body'
  actionpack (4.2.7.1) lib/abstract_controller/rendering.rb:25:in `render'
  actionpack (4.2.7.1) lib/action_controller/metal/rendering.rb:16:in `render'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:44:in `block (2 levels) in render'
  activesupport (4.2.7.1) lib/active_support/core_ext/benchmark.rb:12:in `block in ms'
  /Users/talha.saifi/.rvm/rubies/ruby-2.2.5/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
  activesupport (4.2.7.1) lib/active_support/core_ext/benchmark.rb:12:in `ms'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:44:in `block in render'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:87:in `cleanup_view_runtime'
  activerecord (4.2.7.1) lib/active_record/railties/controller_runtime.rb:25:in `cleanup_view_runtime'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:43:in `render'
   () Users/talha.saifi/.rvm/gems/ruby-2.2.5/bundler/gems/health-monitor-rails-074d6cf02c68/app/controllers/health_monitor/health_controller.rb:18:in `block (2 levels) in check'
  actionpack (4.2.7.1) lib/action_controller/metal/mime_responds.rb:217:in `respond_to'
   () Users/talha.saifi/.rvm/gems/ruby-2.2.5/bundler/gems/health-monitor-rails-074d6cf02c68/app/controllers/health_monitor/health_controller.rb:14:in `check'
  actionpack (4.2.7.1) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
  actionpack (4.2.7.1) lib/abstract_controller/base.rb:198:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/rendering.rb:10:in `process_action'
  actionpack (4.2.7.1) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:117:in `call'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:505:in `call'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:498:in `block (2 levels) in around'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:313:in `block (2 levels) in halting'
  react-rails (2.2.1) lib/react/rails/controller_lifecycle.rb:31:in `use_react_component_helper'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:432:in `block in make_lambda'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:312:in `block in halting'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:497:in `block in around'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:505:in `call'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:92:in `__run_callbacks__'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.7.1) lib/abstract_controller/callbacks.rb:19:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/rescue.rb:29:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:32:in `block in process_action'
  activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in `block in instrument'
  activesupport (4.2.7.1) lib/active_support/notifications/instrumenter.rb:20:in `instrument'
  activesupport (4.2.7.1) lib/active_support/notifications.rb:164:in `instrument'
  actionpack (4.2.7.1) lib/action_controller/metal/instrumentation.rb:30:in `process_action'
  actionpack (4.2.7.1) lib/action_controller/metal/params_wrapper.rb:250:in `process_action'
  activerecord (4.2.7.1) lib/active_record/railties/controller_runtime.rb:18:in `process_action'
  actionpack (4.2.7.1) lib/abstract_controller/base.rb:137:in `process'
  actionview (4.2.7.1) lib/action_view/rendering.rb:30:in `process'
  rack-mini-profiler (0.10.1) lib/mini_profiler/profiling_methods.rb:102:in `block in profile_method'
  actionpack (4.2.7.1) lib/action_controller/metal.rb:196:in `dispatch'
  actionpack (4.2.7.1) lib/action_controller/metal/rack_delegation.rb:13:in `dispatch'
  actionpack (4.2.7.1) lib/action_controller/metal.rb:237:in `block in action'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:74:in `dispatch'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:43:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:817:in `call'
  railties (4.2.7.1) lib/rails/engine.rb:518:in `call'
  railties (4.2.7.1) lib/rails/railtie.rb:194:in `method_missing'
  actionpack (4.2.7.1) lib/action_dispatch/routing/mapper.rb:51:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:43:in `block in serve'
  actionpack (4.2.7.1) lib/action_dispatch/journey/router.rb:30:in `serve'
  actionpack (4.2.7.1) lib/action_dispatch/routing/route_set.rb:817:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  omniauth (1.6.1) lib/omniauth/strategy.rb:407:in `call_app!'
  omniauth (1.6.1) lib/omniauth/strategy.rb:265:in `mock_call!'
  omniauth (1.6.1) lib/omniauth/strategy.rb:184:in `call!'
  omniauth (1.6.1) lib/omniauth/strategy.rb:167:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/rack/agent_hooks.rb:30:in `traced_call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/rack/browser_monitoring.rb:32:in `traced_call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  warden (1.2.6) lib/warden/manager.rb:35:in `block in call'
  warden (1.2.6) lib/warden/manager.rb:34:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/etag.rb:24:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/conditionalget.rb:25:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/head.rb:13:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/flash.rb:260:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.6.8) lib/rack/session/abstract/id.rb:220:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  activerecord (4.2.7.1) lib/active_record/query_cache.rb:36:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  activerecord (4.2.7.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:653:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  activerecord (4.2.7.1) lib/active_record/migration.rb:377:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:88:in `__run_callbacks__'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:778:in `_run_call_callbacks'
  activesupport (4.2.7.1) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/reloader.rb:73:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/remote_ip.rb:78:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:84:in `protected_app_call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:79:in `better_errors_call'
  better_errors (2.1.1) lib/better_errors/middleware.rb:57:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  railties (4.2.7.1) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.2.7.1) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.2.7.1) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.2.7.1) lib/rails/rack/logger.rb:20:in `call'
  quiet_assets (1.1.0) lib/quiet_assets.rb:27:in `call_with_quiet_assets'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  request_store (1.3.1) lib/request_store/middleware.rb:9:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/methodoverride.rb:22:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/runtime.rb:18:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  activesupport (4.2.7.1) lib/active_support/cache/strategy/local_cache_middleware.rb:28:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/lock.rb:17:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  actionpack (4.2.7.1) lib/action_dispatch/middleware/static.rb:120:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/sendfile.rb:113:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack-mini-profiler (0.10.1) lib/mini_profiler/profiler.rb:278:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  railties (4.2.7.1) lib/rails/engine.rb:518:in `call'
  railties (4.2.7.1) lib/rails/application.rb:165:in `call'
  newrelic_rpm (4.4.0.336) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
  rack (1.6.8) lib/rack/content_length.rb:15:in `call'
  thin (1.5.1) lib/thin/connection.rb:81:in `block in pre_process'
  thin (1.5.1) lib/thin/connection.rb:79:in `pre_process'
  thin (1.5.1) lib/thin/connection.rb:54:in `process'
  thin (1.5.1) lib/thin/connection.rb:39:in `receive_data'
  eventmachine (1.0.9.1) lib/eventmachine.rb:193:in `run'
  thin (1.5.1) lib/thin/backends/base.rb:63:in `start'
  thin (1.5.1) lib/thin/server.rb:159:in `start'
  rack (1.6.8) lib/rack/handler/thin.rb:19:in `run'
  rack (1.6.8) lib/rack/server.rb:287:in `start'
  railties (4.2.7.1) lib/rails/commands/server.rb:80:in `start'
  railties (4.2.7.1) lib/rails/commands/commands_tasks.rb:80:in `block in server'
  railties (4.2.7.1) lib/rails/commands/commands_tasks.rb:75:in `server'
  railties (4.2.7.1) lib/rails/commands/commands_tasks.rb:39:in `run_command!'
  railties (4.2.7.1) lib/rails/commands.rb:17:in `<top (required)>'
  bin/rails:9:in `<main>'
```