### PR TITLE
Replace dependancy for rails with railties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ matrix:
       gemfile: gemfiles/rails_6.0.gemfile
     - rvm: 2.4.5
       gemfile: gemfiles/rails_6.0.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_5.0.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_5.1.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_5.2.gemfile
 script:
   - bundle exec rake rubocop
   - bundle exec rspec

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -4,7 +4,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5.0.7.1'
+gem 'railties', '~> 5.0.7.1'
 gem 'sqlite3', '~> 1.3.6'
 
 gemspec path: '../'

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -4,7 +4,7 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5.1.6.1'
+gem 'railties', '~> 5.1.6.1'
 gem 'sqlite3', '~> 1.3.6'
 
 gemspec path: '../'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -4,6 +4,6 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '~> 5.2.2'
+gem 'railties', '~> 5.2.2'
 
 gemspec path: '../'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -4,6 +4,6 @@
 
 source 'https://rubygems.org'
 
-gem 'rails', '~> 6.0.0'
+gem 'railties', '~> 6.0.0'
 
 gemspec path: '../'

--- a/health-monitor-rails.gemspec
+++ b/health-monitor-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'rails', '>= 4.0'
+  s.add_dependency 'railties', '>= 4.0'
 
   s.add_development_dependency 'appraisal'
   s.add_development_dependency 'capybara'

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -15,9 +15,6 @@ Dummy::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -61,10 +61,6 @@ Dummy::Application.configure do
   # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
   # config.assets.precompile += %w( search.js )
 
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found).
   config.i18n.fallbacks = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -24,11 +24,6 @@ Dummy::Application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
In my current project I'm not using all of rails due to it being a heavy framework of which I'm not using all of.

This is the only gem left that has a dependancy on all of rails.

This change removes gems that you don't actually depend on from dependancies (actioncable, actionmailbox, actionmailer, actiontext...) but keeps the rails core and gems you still need (actionpack, actionview, activemodel, activesupport...)

All the specs passed for me but since you don't have a proper contribution guide, I may have missed something during project setup. If there is anything else you'd like me to change, let me know.