### PR TITLE
Use formatted rather than deprecated to_s

### DIFF
--- a/lib/health_monitor/monitor.rb
+++ b/lib/health_monitor/monitor.rb
@@ -29,7 +29,7 @@ module HealthMonitor
     {
       results: results,
       status: results.any? { |res| res[:status] != STATUSES[:ok] } ? :service_unavailable : :ok,
-      timestamp: Time.now.to_s(:rfc2822)
+      timestamp: Time.now.to_formatted_s(:rfc2822)
     }
   end
 

--- a/lib/health_monitor/providers/redis.rb
+++ b/lib/health_monitor/providers/redis.rb
@@ -37,7 +37,7 @@ module HealthMonitor
       private
 
       def check_values!
-        time = Time.now.to_s(:rfc2822)
+        time = Time.now.to_formatted_s(:rfc2822)
 
         redis.set(key, time)
         fetched = redis.get(key)

--- a/spec/controllers/health_monitor/health_controller_spec.rb
+++ b/spec/controllers/health_monitor/health_controller_spec.rb
@@ -49,7 +49,7 @@ describe HealthMonitor::HealthController, type: :controller do
             }
           ],
           'status' => 'ok',
-          'timestamp' => time.to_s(:rfc2822)
+          'timestamp' => time.to_formatted_s(:rfc2822)
         )
       end
 
@@ -79,7 +79,7 @@ describe HealthMonitor::HealthController, type: :controller do
                 }
               ],
               'status' => 'ok',
-              'timestamp' => time.to_s(:rfc2822)
+              'timestamp' => time.to_formatted_s(:rfc2822)
             )
           end
         end
@@ -95,7 +95,7 @@ describe HealthMonitor::HealthController, type: :controller do
             expect(JSON.parse(response.body)).to eq(
               'results' => [],
               'status' => 'ok',
-              'timestamp' => time.to_s(:rfc2822)
+              'timestamp' => time.to_formatted_s(:rfc2822)
             )
           end
         end
@@ -111,7 +111,7 @@ describe HealthMonitor::HealthController, type: :controller do
             expect(JSON.parse(response.body)).to eq(
               'results' => [],
               'status' => 'ok',
-              'timestamp' => time.to_s(:rfc2822)
+              'timestamp' => time.to_formatted_s(:rfc2822)
             )
           end
         end
@@ -161,7 +161,7 @@ describe HealthMonitor::HealthController, type: :controller do
             }
           ],
           'status' => 'ok',
-          'timestamp' => time.to_s(:rfc2822),
+          'timestamp' => time.to_formatted_s(:rfc2822),
           'environment_variables' => {
             'build_number' => '12',
             'git_sha' => 'example_sha'
@@ -195,7 +195,7 @@ describe HealthMonitor::HealthController, type: :controller do
             }
           ],
           'status' => 'ok',
-          'timestamp' => time.to_s(:rfc2822)
+          'timestamp' => time.to_formatted_s(:rfc2822)
         )
       end
 
@@ -221,7 +221,7 @@ describe HealthMonitor::HealthController, type: :controller do
               }
             ],
             'status' => 'service_unavailable',
-            'timestamp' => time.to_s(:rfc2822)
+            'timestamp' => time.to_formatted_s(:rfc2822)
           )
         end
       end
@@ -243,7 +243,7 @@ describe HealthMonitor::HealthController, type: :controller do
             }
           ],
           'status' => 'ok',
-          'timestamp' => time.to_s(:rfc2822)
+          'timestamp' => time.to_formatted_s(:rfc2822)
         )
       end
 
@@ -269,7 +269,7 @@ describe HealthMonitor::HealthController, type: :controller do
               }
             ],
             'status' => 'service_unavailable',
-            'timestamp' => time.to_s(:rfc2822)
+            'timestamp' => time.to_formatted_s(:rfc2822)
           )
         end
       end

--- a/spec/lib/health_monitor/monitor_spec.rb
+++ b/spec/lib/health_monitor/monitor_spec.rb
@@ -107,7 +107,7 @@ describe HealthMonitor do
             }
           ],
           status: :ok,
-          timestamp: time.to_s(:rfc2822)
+          timestamp: time.to_formatted_s(:rfc2822)
         )
       end
     end
@@ -135,7 +135,7 @@ describe HealthMonitor do
             }
           ],
           status: :ok,
-          timestamp: time.to_s(:rfc2822)
+          timestamp: time.to_formatted_s(:rfc2822)
         )
       end
 
@@ -159,7 +159,7 @@ describe HealthMonitor do
               }
             ],
             status: :service_unavailable,
-            timestamp: time.to_s(:rfc2822)
+            timestamp: time.to_formatted_s(:rfc2822)
           )
         end
       end
@@ -184,7 +184,7 @@ describe HealthMonitor do
               }
             ],
             status: :ok,
-            timestamp: time.to_s(:rfc2822)
+            timestamp: time.to_formatted_s(:rfc2822)
           )
         end
       end
@@ -210,7 +210,7 @@ describe HealthMonitor do
               }
             ],
             status: :service_unavailable,
-            timestamp: time.to_s(:rfc2822)
+            timestamp: time.to_formatted_s(:rfc2822)
           )
         end
       end
@@ -248,7 +248,7 @@ describe HealthMonitor do
             }
           ],
           status: :service_unavailable,
-          timestamp: time.to_s(:rfc2822)
+          timestamp: time.to_formatted_s(:rfc2822)
         )
 
         expect(test).to be_truthy


### PR DESCRIPTION
This changes the time format `from to_s(:format)` to ` to_formatted_s(:format)`.

Should address the issues encountered in #75.

