### PR TITLE
Allow duplicate configurations

### DIFF
--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -33,7 +33,7 @@ module HealthMonitor
     private
 
     def add_provider(provider_class)
-      (@providers ||= Set.new) << provider_class
+      (@providers ||= []) << provider_class
 
       provider_class
     end

--- a/spec/lib/health_monitor/configuration_spec.rb
+++ b/spec/lib/health_monitor/configuration_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe HealthMonitor::Configuration do
-  let(:default_configuration) { Set.new([HealthMonitor::Providers::Database]) }
+  let(:default_configuration) { [HealthMonitor::Providers::Database] }
 
   describe 'defaults' do
     it { expect(subject.providers).to eq(default_configuration) }
@@ -14,7 +14,7 @@ describe HealthMonitor::Configuration do
   describe 'providers' do
     HealthMonitor::Configuration::PROVIDERS.each do |provider_name|
       before do
-        subject.instance_variable_set('@providers', Set.new)
+        subject.instance_variable_set('@providers', [])
 
         stub_const("HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}", Class.new)
       end
@@ -26,7 +26,7 @@ describe HealthMonitor::Configuration do
       it "configures #{provider_name}" do
         expect {
           subject.send(provider_name)
-        }.to change { subject.providers }.to(Set.new(["HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}".constantize]))
+        }.to change { subject.providers }.to(["HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}".constantize])
       end
 
       it "returns #{provider_name}'s class" do
@@ -37,7 +37,7 @@ describe HealthMonitor::Configuration do
 
   describe '#add_custom_provider' do
     before do
-      subject.instance_variable_set('@providers', Set.new)
+      subject.instance_variable_set('@providers', [])
     end
 
     context 'inherits' do
@@ -47,7 +47,7 @@ describe HealthMonitor::Configuration do
       it 'accepts' do
         expect {
           subject.add_custom_provider(CustomProvider)
-        }.to change { subject.providers }.to(Set.new([CustomProvider]))
+        }.to change { subject.providers }.to([CustomProvider])
       end
 
       it 'returns CustomProvider class' do
@@ -71,7 +71,7 @@ describe HealthMonitor::Configuration do
     it 'removes the default database check' do
       expect {
         subject.no_database
-      }.to change { subject.providers }.from(default_configuration).to(Set.new)
+      }.to change { subject.providers }.from(default_configuration).to([])
     end
   end
 end

--- a/spec/lib/health_monitor/monitor_spec.rb
+++ b/spec/lib/health_monitor/monitor_spec.rb
@@ -23,7 +23,7 @@ describe HealthMonitor do
         expect {
           subject.configure(&:redis)
         }.to change { HealthMonitor.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis]))
+          .to([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis])
       end
 
       it 'configures a single provider with custom configuration' do
@@ -32,7 +32,7 @@ describe HealthMonitor do
             redis_config.url = 'redis://user:pass@example.redis.com:90210/'
           end
         }.to change { HealthMonitor.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis]))
+          .to([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis])
       end
 
       it 'configures a multiple providers' do
@@ -42,8 +42,8 @@ describe HealthMonitor do
             config.sidekiq
           end
         }.to change { HealthMonitor.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis,
-            HealthMonitor::Providers::Sidekiq]))
+          .to([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis,
+            HealthMonitor::Providers::Sidekiq])
       end
 
       it 'configures multiple providers with custom configuration' do
@@ -55,15 +55,15 @@ describe HealthMonitor do
             end
           end
         }.to change { HealthMonitor.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis,
-            HealthMonitor::Providers::Sidekiq]))
+          .to([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis,
+            HealthMonitor::Providers::Sidekiq])
       end
 
       it 'appends new providers' do
         expect {
           subject.configure(&:resque)
-        }.to change { HealthMonitor.configuration.providers }.to(Set.new([HealthMonitor::Providers::Database,
-          HealthMonitor::Providers::Resque]))
+        }.to change { HealthMonitor.configuration.providers }.to([HealthMonitor::Providers::Database,
+          HealthMonitor::Providers::Resque])
       end
     end
 


### PR DESCRIPTION
Removes the need for a Set.new() and changes it to an array. Should allow for duplicate configurations for the same type.

#66 