### PR TITLE
Fix issue "Unable to connect to: primary" for PostgreSQL

### DIFF
--- a/lib/health_monitor/providers/database.rb
+++ b/lib/health_monitor/providers/database.rb
@@ -11,7 +11,7 @@ module HealthMonitor
         failed_databases = []
 
         ActiveRecord::Base.connection_handler.all_connection_pools.each do |cp|
-          cp.connection.schema_version
+          cp.connection.check_version
         rescue Exception
           failed_databases << cp.db_config.name
         end

--- a/spec/support/providers.rb
+++ b/spec/support/providers.rb
@@ -13,7 +13,7 @@ module Providers
   end
 
   def stub_database_failure(database = nil)
-    allow_any_instance_of(ActiveRecord::ConnectionAdapters::AbstractAdapter).to receive(:schema_version) do |instance|
+    allow_any_instance_of(ActiveRecord::ConnectionAdapters::AbstractAdapter).to receive(:check_version) do |instance|
       raise StandardError if !database.present? || instance.pool.db_config.name == database.to_s
     end
   end


### PR DESCRIPTION
Hi there, 

Thanks for this awesome tool! With the latest update (v9.5.0) the monitoring tool gives back the following error: 

```
ERROR
unable to connect to: primary
```

I was looking into in and the change made [here](https://github.com/lbeder/health-monitor-rails/compare/v9.4.0...v9.5.0#diff-c680c6b73954c2c8320d57365e38c0ccaaf2037e4ff2ebfcaa2fa3593ba5b368R11-R19) seems to caused it. The error I'm getting while running the code is: 

```
> ActiveRecord::Base.connection_handler.all_connection_pools.each do |cp|
>   cp.connection.schema_version
> end

=> undefined method `schema_version' for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
```

If I change it to the suggested `check_version` it's working for me.