### PR TITLE
Prevent duplicative status checks on JSON and XML endpoints

### DIFF
--- a/app/controllers/health_monitor/health_controller.rb
+++ b/app/controllers/health_monitor/health_controller.rb
@@ -16,8 +16,8 @@ module HealthMonitor
 
       respond_to do |format|
         format.html
-        format.json { render json: statuses.to_json, status: statuses[:status] }
-        format.xml { render xml: statuses.to_xml, status: statuses[:status] }
+        format.json { render json: @statuses.to_json, status: @statuses[:status] }
+        format.xml { render xml: @statuses.to_xml, status: @statuses[:status] }
       end
     end
 


### PR DESCRIPTION
If making JSON or XML requests, then the `statuses` method was called 3 separate times. This meant that 3 separate status checks were performed for every configured provider on every request to the `/check` route. In rare cases, this could also lead to the JSON data not matching with the HTTP status code being returned since these were referencing separate status data.