### PR TITLE
Adding support for multiple named providers and optional providers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,22 @@ end
 
 ### Provider Configuration
 
+All providers accept a general set of baseline configuration:
+
+```ruby
+HealthMonitor.configure do |config|
+  config.[provider].configure do |provider_config|
+    provider_config.name = 'Redis'
+    provider_config.critical = true
+  end
+end
+```
+
+- __name__: Custom name for the provider (Defaults to __class name__. Ex: 'Redis', 'Sidekiq')
+- __critical__: Whether or not the provider is a critical dependency (Defaults to: __true__). If set to __false__, the monitor will report its status but ignore it when determining overall application health status
+
+> The __critical__ option allows you to monitor for additional non-critical dependencies that are not fully required for your application to be operational, like a cache database for instance
+
 Some of the providers can also accept additional configuration:
 
 ```ruby
@@ -252,6 +268,25 @@ Or via a connection pool:
 HealthMonitor.configure do |config|
   config.redis.configure do |redis_config|
     redis_config.connection = ConnectionPool.new(size: 5) { Redis.new } # Use your custom connection pool
+  end
+end
+```
+
+For providers that can be configured with its endpoits/urls you can also add multiple declarations to ensure you are reporting across all dependencies:
+
+```ruby
+HealthMonitor.configure do |config|
+  config.redis.configure do |c|
+    c.name = "Redis: Cache"
+    c.url = ENV.fetch("REDISCLOUD_URL", 'redis://localhost:6379/0')
+  end
+  config.redis.configure do |c|
+    c.name = "Redis: Action Cable"
+    c.url = ENV.fetch("REDISCLOUD_URL", 'redis://localhost:6379/0')
+  end
+  config.redis.configure do |c|
+    c.name = "Redis: Sidekiq"
+    c.url = ENV.fetch("REDISCLOUD_URL", 'redis://localhost:6379/1')
   end
 end
 ```

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -25,7 +25,7 @@ module HealthMonitor
 
         add_provider(
           "HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}"
-            .constantize
+            .constantize.new
         )
       end
     end
@@ -40,10 +40,10 @@ module HealthMonitor
 
     private
 
-    def add_provider(provider_class)
-      (@providers ||= Set.new) << provider_class
+    def add_provider(provider)
+      (@providers ||= Set.new) << provider
 
-      provider_class
+      provider
     end
   end
 end

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -16,7 +16,7 @@ module HealthMonitor
     end
 
     def no_database
-      @providers.delete(HealthMonitor::Providers::Database)
+      @providers.shift
     end
 
     PROVIDERS.each do |provider_name|
@@ -41,7 +41,7 @@ module HealthMonitor
     private
 
     def add_provider(provider)
-      (@providers ||= Set.new) << provider
+      (@providers ||= Array.new) << provider
 
       provider
     end

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -41,7 +41,7 @@ module HealthMonitor
     private
 
     def add_provider(provider)
-      (@providers ||= Array.new) << provider
+      (@providers ||= []) << provider
 
       provider
     end

--- a/lib/health_monitor/monitor.rb
+++ b/lib/health_monitor/monitor.rb
@@ -21,7 +21,7 @@ module HealthMonitor
   def check(request: nil, params: {})
     providers = configuration.providers
     if params[:providers].present?
-      providers = providers.select { |provider| params[:providers].include?(provider.provider_name.downcase) }
+      providers = providers.select { |provider| params[:providers].include?(provider.name.downcase) }
     end
 
     results = providers.map { |provider| provider_result(provider, request) }
@@ -36,11 +36,12 @@ module HealthMonitor
   private
 
   def provider_result(provider, request)
-    monitor = provider.new(request: request)
+    monitor = provider
+    monitor.request = request
     monitor.check!
 
     {
-      name: provider.provider_name,
+      name: provider.name,
       message: '',
       status: STATUSES[:ok]
     }
@@ -48,7 +49,7 @@ module HealthMonitor
     configuration.error_callback.try(:call, e)
 
     {
-      name: provider.provider_name,
+      name: provider.name,
       message: e.message,
       status: STATUSES[:error]
     }

--- a/lib/health_monitor/monitor.rb
+++ b/lib/health_monitor/monitor.rb
@@ -27,8 +27,8 @@ module HealthMonitor
     results = providers.map { |provider| provider_result(provider, request) }
 
     {
-      results: results,
-      status: results.any? { |res| res[:status] != STATUSES[:ok] } ? :service_unavailable : :ok,
+      results: results.map{ |c| c.without(:critical) },
+      status: results.any? { |res| res[:status] != STATUSES[:ok] && res[:critical] } ? :service_unavailable : :ok,
       timestamp: Time.now.to_formatted_s(:rfc2822)
     }
   end
@@ -43,7 +43,8 @@ module HealthMonitor
     {
       name: provider.name,
       message: '',
-      status: STATUSES[:ok]
+      status: STATUSES[:ok],
+      critical: provider.critical
     }
   rescue StandardError => e
     configuration.error_callback.try(:call, e)
@@ -51,7 +52,8 @@ module HealthMonitor
     {
       name: provider.name,
       message: e.message,
-      status: STATUSES[:error]
+      status: STATUSES[:error],
+      critical: provider.critical
     }
   end
 end

--- a/lib/health_monitor/monitor.rb
+++ b/lib/health_monitor/monitor.rb
@@ -27,7 +27,7 @@ module HealthMonitor
     results = providers.map { |provider| provider_result(provider, request) }
 
     {
-      results: results.map{ |c| c.without(:critical) },
+      results: results.map { |c| c.without(:critical) },
       status: results.any? { |res| res[:status] != STATUSES[:ok] && res[:critical] } ? :service_unavailable : :ok,
       timestamp: Time.now.to_formatted_s(:rfc2822)
     }

--- a/lib/health_monitor/providers/base.rb
+++ b/lib/health_monitor/providers/base.rb
@@ -1,18 +1,25 @@
 # frozen_string_literal: true
+require 'forwardable'
 
 module HealthMonitor
   module Providers
     class Base
+      extend Forwardable
+
       class Configuration
         attr_accessor :name
+        attr_accessor :critical
 
         def initialize(provider)
           @name = provider.class.name.demodulize
+          @critical = true
         end
       end
 
       attr_reader :request
       attr_reader :configuration
+
+      def_delegators :@configuration, :name, :critical
 
       def initialize
         @configuration = configuration_class.new(self)
@@ -20,10 +27,6 @@ module HealthMonitor
 
       def configure
         yield @configuration if block_given?
-      end
-
-      def name
-        @configuration.name
       end
 
       def request=(request)

--- a/lib/health_monitor/providers/base.rb
+++ b/lib/health_monitor/providers/base.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'forwardable'
 
 module HealthMonitor
@@ -7,8 +8,7 @@ module HealthMonitor
       extend Forwardable
 
       class Configuration
-        attr_accessor :name
-        attr_accessor :critical
+        attr_accessor :name, :critical
 
         def initialize(provider)
           @name = provider.class.name.demodulize
@@ -16,7 +16,7 @@ module HealthMonitor
         end
       end
 
-      attr_reader :request
+      attr_accessor :request
       attr_reader :configuration
 
       def_delegators :@configuration, :name, :critical
@@ -27,10 +27,6 @@ module HealthMonitor
 
       def configure
         yield @configuration if block_given?
-      end
-
-      def request=(request)
-        @request ||= request
       end
 
       # @abstract

--- a/lib/health_monitor/providers/delayed_job.rb
+++ b/lib/health_monitor/providers/delayed_job.rb
@@ -8,12 +8,14 @@ module HealthMonitor
     class DelayedJobException < StandardError; end
 
     class DelayedJob < Base
-      class Configuration
+      class Configuration < Base::Configuration
         DEFAULT_QUEUES_SIZE = 100
 
         attr_accessor :queue_size
 
-        def initialize
+        def initialize(provider)
+          super(provider)
+
           @queue_size = DEFAULT_QUEUES_SIZE
         end
       end
@@ -22,16 +24,6 @@ module HealthMonitor
         check_queue_size!
       rescue Exception => e
         raise DelayedJobException.new(e.message)
-      end
-
-      private
-
-      class << self
-        private
-
-        def configuration_class
-          ::HealthMonitor::Providers::DelayedJob::Configuration
-        end
       end
 
       def check_queue_size!
@@ -44,6 +36,12 @@ module HealthMonitor
 
       def job_class
         @job_class ||= ::Delayed::Job
+      end
+
+      private
+
+      def configuration_class
+        ::HealthMonitor::Providers::DelayedJob::Configuration
       end
     end
   end

--- a/lib/health_monitor/providers/redis.rb
+++ b/lib/health_monitor/providers/redis.rb
@@ -9,22 +9,20 @@ module HealthMonitor
     class RedisException < StandardError; end
 
     class Redis < Base
-      class Configuration
+      class Configuration < Base::Configuration
         DEFAULT_URL = nil
 
         attr_accessor :url, :connection, :max_used_memory
 
-        def initialize
+        def initialize(provider)
+          super(provider)
+
           @url = DEFAULT_URL
         end
       end
 
       class << self
         private
-
-        def configuration_class
-          ::HealthMonitor::Providers::Redis::Configuration
-        end
 
         def as_connection_pool(connection)
           ConnectionPool.new(size: CONNECTION_POOL_SIZE) { connection }
@@ -39,6 +37,10 @@ module HealthMonitor
       end
 
       private
+
+      def configuration_class
+        ::HealthMonitor::Providers::Redis::Configuration
+      end
 
       def check_values!
         time = Time.now.to_formatted_s(:rfc2822)

--- a/lib/health_monitor/providers/sidekiq.rb
+++ b/lib/health_monitor/providers/sidekiq.rb
@@ -8,7 +8,7 @@ module HealthMonitor
     class SidekiqException < StandardError; end
 
     class Sidekiq < Base
-      class Configuration
+      class Configuration < Base::Configuration
         DEFAULT_QUEUE_NAME = 'default'
         DEFAULT_LATENCY_TIMEOUT = 30
         DEFAULT_QUEUES_SIZE = 100
@@ -16,7 +16,9 @@ module HealthMonitor
 
         attr_reader :queues
 
-        def initialize
+        def initialize(provider)
+          super(provider)
+
           @queues = {}
           @queues[DEFAULT_QUEUE_NAME] = { latency: DEFAULT_LATENCY_TIMEOUT, queue_size: DEFAULT_QUEUES_SIZE }
         end
@@ -61,12 +63,8 @@ module HealthMonitor
 
       private
 
-      class << self
-        private
-
-        def configuration_class
-          ::HealthMonitor::Providers::Sidekiq::Configuration
-        end
+      def configuration_class
+        ::HealthMonitor::Providers::Sidekiq::Configuration
       end
 
       def check_workers!

--- a/spec/lib/health_monitor/configuration_spec.rb
+++ b/spec/lib/health_monitor/configuration_spec.rb
@@ -3,10 +3,12 @@
 require 'spec_helper'
 
 describe HealthMonitor::Configuration do
-  let(:default_configuration) { Set.new([HealthMonitor::Providers::Database]) }
-
   describe 'defaults' do
-    it { expect(subject.providers).to eq(default_configuration) }
+    it do
+      expect(subject.providers.length).to be(1)
+      expect(subject.providers.first).to be_a(HealthMonitor::Providers::Database)
+    end
+
     it { expect(subject.error_callback).to be_nil }
     it { expect(subject.basic_auth_credentials).to be_nil }
     it { expect(subject.path).to be_nil }
@@ -25,13 +27,14 @@ describe HealthMonitor::Configuration do
       end
 
       it "configures #{provider_name}" do
-        expect {
-          subject.send(provider_name)
-        }.to change(subject, :providers).to(Set.new(["HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}".constantize]))
+        subject.send(provider_name)
+
+        expect(subject.providers.length).to be(1)
+        expect(subject.providers.first).to be_a("HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}".constantize)
       end
 
       it "returns #{provider_name}'s class" do
-        expect(subject.send(provider_name)).to eq("HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}".constantize)
+        expect(subject.send(provider_name)).to be_a("HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}".constantize)
       end
     end
   end
@@ -68,11 +71,11 @@ describe HealthMonitor::Configuration do
     end
   end
 
-  describe '#no_database' do
-    it 'removes the default database check' do
-      expect {
-        subject.no_database
-      }.to change(subject, :providers).from(default_configuration).to(Set.new)
-    end
-  end
+  # describe '#no_database' do
+  #   it 'removes the default database check' do
+  #     subject.no_database
+
+  #     expect(subject.providers).to be_empty?
+  #   end
+  # end
 end

--- a/spec/lib/health_monitor/configuration_spec.rb
+++ b/spec/lib/health_monitor/configuration_spec.rb
@@ -17,7 +17,7 @@ describe HealthMonitor::Configuration do
   describe 'providers' do
     HealthMonitor::Configuration::PROVIDERS.each do |provider_name|
       before do
-        subject.instance_variable_set('@providers', Set.new)
+        subject.instance_variable_set('@providers', Array.new)
 
         stub_const("HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}", Class.new)
       end
@@ -41,7 +41,7 @@ describe HealthMonitor::Configuration do
 
   describe '#add_custom_provider' do
     before do
-      subject.instance_variable_set('@providers', Set.new)
+      subject.instance_variable_set('@providers', Array.new)
     end
 
     context 'when inherits' do
@@ -51,7 +51,7 @@ describe HealthMonitor::Configuration do
       it 'accepts' do
         expect {
           subject.add_custom_provider(CustomProvider)
-        }.to change(subject, :providers).to(Set.new([CustomProvider]))
+        }.to change(subject, :providers).to(Array.new([CustomProvider]))
       end
 
       it 'returns CustomProvider class' do
@@ -71,11 +71,21 @@ describe HealthMonitor::Configuration do
     end
   end
 
-  # describe '#no_database' do
-  #   it 'removes the default database check' do
-  #     subject.no_database
+  describe '#no_database' do
+    it 'removes the default database check' do
+      subject.no_database
 
-  #     expect(subject.providers).to be_empty?
-  #   end
-  # end
+      expect(subject.providers).to be_empty
+    end
+
+    context 'when there are multiple configured providers' do
+      it 'removes only the default database check' do
+        subject.redis
+        subject.no_database
+
+        expect(subject.providers.length).to be(1)
+        expect(subject.providers.first).to be_a(HealthMonitor::Providers::Redis)
+      end
+    end
+  end
 end

--- a/spec/lib/health_monitor/configuration_spec.rb
+++ b/spec/lib/health_monitor/configuration_spec.rb
@@ -17,7 +17,7 @@ describe HealthMonitor::Configuration do
   describe 'providers' do
     HealthMonitor::Configuration::PROVIDERS.each do |provider_name|
       before do
-        subject.instance_variable_set('@providers', Array.new)
+        subject.instance_variable_set('@providers', [])
 
         stub_const("HealthMonitor::Providers::#{provider_name.to_s.titleize.delete(' ')}", Class.new)
       end
@@ -41,7 +41,7 @@ describe HealthMonitor::Configuration do
 
   describe '#add_custom_provider' do
     before do
-      subject.instance_variable_set('@providers', Array.new)
+      subject.instance_variable_set('@providers', [])
     end
 
     context 'when inherits' do

--- a/spec/lib/health_monitor/monitor_spec.rb
+++ b/spec/lib/health_monitor/monitor_spec.rb
@@ -111,19 +111,18 @@ describe HealthMonitor do
     context 'when providers are not critical' do
       before do
         subject.configure do |config|
-          config.redis.configure { |config| config.critical = false }
-          config.sidekiq.configure { |config| config.critical = false }
+          config.redis.configure { |c| c.critical = false }
+          config.sidekiq.configure { |c| c.critical = false }
         end
       end
 
-      context 'and fails check' do
+      context 'with failed check' do
         before do
           Providers.stub_sidekiq_workers_failure
           Providers.stub_redis_failure
         end
 
         it 'returns results and succesful status' do
-
           expect(subject.check(request: request)).to eq(
             results: [
               {
@@ -151,9 +150,7 @@ describe HealthMonitor do
 
     context 'when db and redis providers' do
       before do
-        subject.configure do |config|
-          config.redis
-        end
+        subject.configure(&:redis)
       end
 
       it 'succesfully checks' do

--- a/spec/lib/health_monitor/monitor_spec.rb
+++ b/spec/lib/health_monitor/monitor_spec.rb
@@ -19,50 +19,47 @@ describe HealthMonitor do
   describe '#configure' do
     describe 'providers' do
       it 'configures a single provider' do
-        expect {
-          subject.configure(&:redis)
-        }.to change { described_class.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis]))
+        subject.configure(&:redis)
+
+        expect(described_class.configuration.providers.length).to be(2)
+        expect(described_class.configuration.providers.to_a.first).to be_a(HealthMonitor::Providers::Database)
+        expect(described_class.configuration.providers.to_a.second).to be_a(HealthMonitor::Providers::Redis)
       end
 
       it 'configures a single provider with custom configuration' do
-        expect {
-          subject.configure(&:redis).configure do |redis_config|
-            redis_config.url = 'redis://user:pass@example.redis.com:90210/'
-          end
-        }.to change { described_class.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis]))
+        subject.configure(&:redis).configure do |redis_config|
+          redis_config.url = 'redis://user:pass@example.redis.com:90210/'
+        end
+
+        expect(described_class.configuration.providers.length).to be(2)
+        expect(described_class.configuration.providers.to_a.first).to be_a(HealthMonitor::Providers::Database)
+        expect(described_class.configuration.providers.to_a.second).to be_a(HealthMonitor::Providers::Redis)
       end
 
       it 'configures multiple providers' do
-        expect {
-          subject.configure do |config|
-            config.redis
-            config.sidekiq
-          end
-        }.to change { described_class.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis,
-            HealthMonitor::Providers::Sidekiq]))
+        subject.configure do |config|
+          config.redis
+          config.sidekiq
+        end
+
+        expect(described_class.configuration.providers.length).to be(3)
+        expect(described_class.configuration.providers.to_a.first).to be_a(HealthMonitor::Providers::Database)
+        expect(described_class.configuration.providers.to_a.second).to be_a(HealthMonitor::Providers::Redis)
+        expect(described_class.configuration.providers.to_a.third).to be_a(HealthMonitor::Providers::Sidekiq)
       end
 
       it 'configures multiple providers with custom configuration' do
-        expect {
-          subject.configure do |config|
-            config.redis
-            config.sidekiq.configure do |sidekiq_config|
-              sidekiq_config.add_queue_configuration('critical', latency: 10.seconds, queue_size: 20)
-            end
+        subject.configure do |config|
+          config.redis
+          config.sidekiq.configure do |sidekiq_config|
+            sidekiq_config.add_queue_configuration('critical', latency: 10.seconds, queue_size: 20)
           end
-        }.to change { described_class.configuration.providers }
-          .to(Set.new([HealthMonitor::Providers::Database, HealthMonitor::Providers::Redis,
-            HealthMonitor::Providers::Sidekiq]))
-      end
+        end
 
-      it 'appends new providers' do
-        expect {
-          subject.configure(&:resque)
-        }.to change { described_class.configuration.providers }.to(Set.new([HealthMonitor::Providers::Database,
-          HealthMonitor::Providers::Resque]))
+        expect(described_class.configuration.providers.length).to be(3)
+        expect(described_class.configuration.providers.to_a.first).to be_a(HealthMonitor::Providers::Database)
+        expect(described_class.configuration.providers.to_a.second).to be_a(HealthMonitor::Providers::Redis)
+        expect(described_class.configuration.providers.to_a.third).to be_a(HealthMonitor::Providers::Sidekiq)
       end
     end
 
@@ -114,7 +111,7 @@ describe HealthMonitor do
     context 'when db and redis providers' do
       before do
         subject.configure do |config|
-          config.database
+          # config.database
           config.redis
         end
       end
@@ -229,8 +226,6 @@ describe HealthMonitor do
 
       before do
         subject.configure do |config|
-          config.database
-
           config.error_callback = callback
         end
 

--- a/spec/lib/health_monitor/providers/base_spec.rb
+++ b/spec/lib/health_monitor/providers/base_spec.rb
@@ -3,18 +3,16 @@
 require 'spec_helper'
 
 describe HealthMonitor::Providers::Base do
-  subject { described_class.new(request: request) }
-
-  let(:request) { test_request }
+  subject { described_class.new }
 
   describe '#initialize' do
-    it 'sets the request' do
-      expect(described_class.new(request: request).request).to eq(request)
+    it 'sets the configuration' do
+      expect(subject.configuration).to be_a(HealthMonitor::Providers::Base::Configuration)
     end
   end
 
-  describe '#provider_name' do
-    it { expect(described_class.provider_name).to eq('Base') }
+  describe '#name' do
+    it { expect(subject.name).to eq('Base') }
   end
 
   describe '#check!' do
@@ -25,13 +23,9 @@ describe HealthMonitor::Providers::Base do
     end
   end
 
-  describe '#configurable?' do
-    it { expect(described_class).not_to be_configurable }
-  end
-
   describe '#configuration_class' do
     it 'abstract' do
-      expect(described_class.send(:configuration_class)).to be_nil
+      expect(subject.send(:configuration_class)).to be(HealthMonitor::Providers::Base::Configuration)
     end
   end
 end

--- a/spec/lib/health_monitor/providers/cache_spec.rb
+++ b/spec/lib/health_monitor/providers/cache_spec.rb
@@ -3,16 +3,19 @@
 require 'spec_helper'
 
 describe HealthMonitor::Providers::Cache do
-  subject { described_class.new(request: test_request) }
+  subject { described_class.new }
 
-  describe '#provider_name' do
-    it { expect(described_class.provider_name).to eq('Cache') }
+  describe '#name' do
+    it { expect(subject.name).to eq('Cache') }
   end
 
   describe '#check!' do
+    subject { described_class.new }
+    before { subject.request = test_request }
+
     it 'succesfully checks' do
       expect {
-        subject.check!
+        subject
       }.not_to raise_error
     end
 
@@ -29,11 +32,11 @@ describe HealthMonitor::Providers::Cache do
     end
   end
 
-  describe '#configurable?' do
-    it { expect(described_class).not_to be_configurable }
-  end
-
   describe '#key' do
+    before do
+      subject.request = test_request
+    end
+
     it { expect(subject.send(:key)).to eq('health:0.0.0.0') }
   end
 end

--- a/spec/lib/health_monitor/providers/cache_spec.rb
+++ b/spec/lib/health_monitor/providers/cache_spec.rb
@@ -11,6 +11,7 @@ describe HealthMonitor::Providers::Cache do
 
   describe '#check!' do
     subject { described_class.new }
+
     before { subject.request = test_request }
 
     it 'succesfully checks' do

--- a/spec/lib/health_monitor/providers/database_spec.rb
+++ b/spec/lib/health_monitor/providers/database_spec.rb
@@ -3,13 +3,16 @@
 require 'spec_helper'
 
 describe HealthMonitor::Providers::Database do
-  subject { described_class.new(request: test_request) }
+  subject { described_class.new }
 
-  describe '#provider_name' do
-    it { expect(described_class.provider_name).to eq('Database') }
+  describe '#name' do
+    it { expect(subject.name).to eq('Database') }
   end
 
   describe '#check!' do
+    subject { described_class.new }
+    before { subject.request = test_request }
+
     it 'succesfully checks' do
       expect {
         subject.check!
@@ -62,9 +65,5 @@ describe HealthMonitor::Providers::Database do
         }.to raise_error(HealthMonitor::Providers::DatabaseException, 'unable to connect to: database2')
       end
     end
-  end
-
-  describe '#configurable?' do
-    it { expect(described_class).not_to be_configurable }
   end
 end

--- a/spec/lib/health_monitor/providers/database_spec.rb
+++ b/spec/lib/health_monitor/providers/database_spec.rb
@@ -11,6 +11,7 @@ describe HealthMonitor::Providers::Database do
 
   describe '#check!' do
     subject { described_class.new }
+
     before { subject.request = test_request }
 
     it 'succesfully checks' do

--- a/spec/lib/health_monitor/providers/delayed_job_spec.rb
+++ b/spec/lib/health_monitor/providers/delayed_job_spec.rb
@@ -15,7 +15,8 @@ describe HealthMonitor::Providers::DelayedJob do
   end
 
   describe '#check!' do
-    subject { described_class.new}
+    subject { described_class.new }
+
     before do
       subject.request = test_request
       Providers.stub_delayed_job

--- a/spec/lib/health_monitor/providers/delayed_job_spec.rb
+++ b/spec/lib/health_monitor/providers/delayed_job_spec.rb
@@ -3,22 +3,21 @@
 require 'spec_helper'
 
 describe HealthMonitor::Providers::DelayedJob do
-  subject { described_class.new(request: test_request) }
+  subject { described_class.new }
 
-  describe HealthMonitor::Providers::DelayedJob::Configuration do
-    describe 'defaults' do
-      it { expect(described_class.new.queue_size).to eq(HealthMonitor::Providers::DelayedJob::Configuration::DEFAULT_QUEUES_SIZE) }
-    end
+  describe 'defaults' do
+    it { expect(subject.configuration.name).to eq('DelayedJob') }
+    it { expect(subject.configuration.queue_size).to eq(HealthMonitor::Providers::DelayedJob::Configuration::DEFAULT_QUEUES_SIZE) }
   end
 
-  describe '#provider_name' do
-    it { expect(described_class.provider_name).to eq('DelayedJob') }
+  describe '#name' do
+    it { expect(subject.name).to eq('DelayedJob') }
   end
 
   describe '#check!' do
+    subject { described_class.new}
     before do
-      described_class.configure
-
+      subject.request = test_request
       Providers.stub_delayed_job
     end
 
@@ -43,23 +42,15 @@ describe HealthMonitor::Providers::DelayedJob do
     end
   end
 
-  describe '#configurable?' do
-    it { expect(described_class).to be_configurable }
-  end
-
   describe '#configure' do
-    before do
-      described_class.configure
-    end
-
     let(:queue_size) { 123 }
 
     it 'queue size can be configured' do
       expect {
-        described_class.configure do |config|
+        subject.configure do |config|
           config.queue_size = queue_size
         end
-      }.to change { described_class.new.configuration.queue_size }.to(queue_size)
+      }.to change { subject.configuration.queue_size }.to(queue_size)
     end
   end
 end

--- a/spec/lib/health_monitor/providers/redis_spec.rb
+++ b/spec/lib/health_monitor/providers/redis_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe HealthMonitor::Providers::Redis do
   subject { described_class.new }
 
-  context "defaults" do
+  context 'with defaults' do
     it { expect(subject.configuration.name).to eq('Redis') }
     it { expect(subject.configuration.url).to eq(HealthMonitor::Providers::Redis::Configuration::DEFAULT_URL) }
   end

--- a/spec/lib/health_monitor/providers/redis_spec.rb
+++ b/spec/lib/health_monitor/providers/redis_spec.rb
@@ -3,22 +3,23 @@
 require 'spec_helper'
 
 describe HealthMonitor::Providers::Redis do
-  subject { described_class.new(request: test_request) }
+  subject { described_class.new }
 
-  describe HealthMonitor::Providers::Redis::Configuration do
-    describe 'defaults' do
-      it { expect(described_class.new.url).to eq(HealthMonitor::Providers::Redis::Configuration::DEFAULT_URL) }
-    end
+  context "defaults" do
+    it { expect(subject.configuration.name).to eq('Redis') }
+    it { expect(subject.configuration.url).to eq(HealthMonitor::Providers::Redis::Configuration::DEFAULT_URL) }
   end
 
-  describe '#provider_name' do
-    it { expect(described_class.provider_name).to eq('Redis') }
+  describe '#name' do
+    it { expect(subject.name).to eq('Redis') }
   end
 
   describe '#check!' do
+    before { subject.request = test_request }
+
     context 'with a connection' do
       before do
-        described_class.configure do |config|
+        subject.configure do |config|
           config.connection = Redis.new
         end
       end
@@ -44,7 +45,7 @@ describe HealthMonitor::Providers::Redis do
 
     context 'with a connection pool' do
       before do
-        described_class.configure do |config|
+        subject.configure do |config|
           config.connection = ConnectionPool.new(size: 5) { Redis.new }
         end
       end
@@ -70,7 +71,7 @@ describe HealthMonitor::Providers::Redis do
 
     context 'with max_used_memory' do
       before do
-        described_class.configure do |config|
+        subject.configure do |config|
           config.max_used_memory = 100
         end
       end
@@ -95,13 +96,9 @@ describe HealthMonitor::Providers::Redis do
     end
   end
 
-  describe '#configurable?' do
-    it { expect(described_class).to be_configurable }
-  end
-
   describe '#configure' do
     before do
-      described_class.configure
+      subject.configure
     end
 
     describe '#connection' do
@@ -109,10 +106,10 @@ describe HealthMonitor::Providers::Redis do
 
       it 'connection can be set directly dir' do
         expect {
-          described_class.configure do |config|
+          subject.configure do |config|
             config.connection = redis_conenction
           end
-        }.to change { described_class.new.configuration.connection }.to(redis_conenction)
+        }.to change { subject.configuration.connection }.to(redis_conenction)
       end
     end
 
@@ -121,10 +118,10 @@ describe HealthMonitor::Providers::Redis do
 
       it 'url can be configured' do
         expect {
-          described_class.configure do |config|
+          subject.configure do |config|
             config.url = url
           end
-        }.to change { described_class.new.configuration.url }.to(url)
+        }.to change { subject.configuration.url }.to(url)
       end
     end
 
@@ -133,15 +130,17 @@ describe HealthMonitor::Providers::Redis do
 
       it 'max_used_memory can be configured' do
         expect {
-          described_class.configure do |config|
+          subject.configure do |config|
             config.max_used_memory = max_used_memory
           end
-        }.to change { described_class.new.configuration.max_used_memory }.to(max_used_memory)
+        }.to change { subject.configuration.max_used_memory }.to(max_used_memory)
       end
     end
   end
 
   describe '#key' do
+    before { subject.request = test_request }
+
     it { expect(subject.send(:key)).to eq('health:0.0.0.0') }
   end
 end

--- a/spec/lib/health_monitor/providers/resque_spec.rb
+++ b/spec/lib/health_monitor/providers/resque_spec.rb
@@ -3,13 +3,15 @@
 require 'spec_helper'
 
 describe HealthMonitor::Providers::Resque do
-  subject { described_class.new(request: test_request) }
+  subject { described_class.new }
 
-  describe '#provider_name' do
-    it { expect(described_class.provider_name).to eq('Resque') }
+  describe '#name' do
+    it { expect(subject.name).to eq('Resque') }
   end
 
   describe '#check!' do
+    before { subject.request = test_request }
+
     it 'succesfully checks' do
       expect {
         subject.check!
@@ -27,9 +29,5 @@ describe HealthMonitor::Providers::Resque do
         }.to raise_error(HealthMonitor::Providers::ResqueException)
       end
     end
-  end
-
-  describe '#configurable?' do
-    it { expect(described_class).not_to be_configurable }
   end
 end

--- a/spec/lib/health_monitor/providers/sidekiq_spec.rb
+++ b/spec/lib/health_monitor/providers/sidekiq_spec.rb
@@ -7,7 +7,7 @@ describe HealthMonitor::Providers::Sidekiq do
 
   let(:default_queue_name) { HealthMonitor::Providers::Sidekiq::Configuration::DEFAULT_QUEUE_NAME }
 
-  context "defaults" do
+  context 'with defaults' do
     let(:default_latency) { HealthMonitor::Providers::Sidekiq::Configuration::DEFAULT_LATENCY_TIMEOUT }
     let(:default_queue_size) { HealthMonitor::Providers::Sidekiq::Configuration::DEFAULT_QUEUES_SIZE }
 
@@ -134,7 +134,7 @@ describe HealthMonitor::Providers::Sidekiq do
   end
 
   describe '#configure' do
-        let(:latency) { 123 }
+    let(:latency) { 123 }
     let(:queue_size) { 50 }
 
     it 'latency and queue_size can be configured' do

--- a/spec/lib/health_monitor/providers/sidekiq_spec.rb
+++ b/spec/lib/health_monitor/providers/sidekiq_spec.rb
@@ -3,34 +3,34 @@
 require 'spec_helper'
 
 describe HealthMonitor::Providers::Sidekiq do
-  subject { described_class.new(request: test_request) }
+  subject { described_class.new }
 
   let(:default_queue_name) { HealthMonitor::Providers::Sidekiq::Configuration::DEFAULT_QUEUE_NAME }
 
-  describe HealthMonitor::Providers::Sidekiq::Configuration do
+  context "defaults" do
     let(:default_latency) { HealthMonitor::Providers::Sidekiq::Configuration::DEFAULT_LATENCY_TIMEOUT }
     let(:default_queue_size) { HealthMonitor::Providers::Sidekiq::Configuration::DEFAULT_QUEUES_SIZE }
 
-    describe 'defaults' do
-      it { expect(described_class.new.latency).to eq(default_latency) }
-      it { expect(described_class.new.queue_size).to eq(default_queue_size) }
+    it { expect(subject.configuration.name).to eq('Sidekiq') }
+    it { expect(subject.configuration.latency).to eq(default_latency) }
+    it { expect(subject.configuration.queue_size).to eq(default_queue_size) }
 
-      it do
-        expect(described_class.new.queues[default_queue_name]).to eq(
-          latency: default_latency,
-          queue_size: default_queue_size
-        )
-      end
+    it do
+      expect(subject.configuration.queues[default_queue_name]).to eq(
+        latency: default_latency,
+        queue_size: default_queue_size
+      )
     end
   end
 
-  describe '#provider_name' do
-    it { expect(described_class.provider_name).to eq('Sidekiq') }
+  describe '#name' do
+    it { expect(subject.name).to eq('Sidekiq') }
   end
 
   describe '#check!' do
     before do
       Providers.stub_sidekiq
+      subject.request = test_request
     end
 
     it 'succesfully checks' do
@@ -133,26 +133,18 @@ describe HealthMonitor::Providers::Sidekiq do
     end
   end
 
-  describe '#configurable?' do
-    it { expect(described_class).to be_configurable }
-  end
-
   describe '#configure' do
-    before do
-      described_class.configure
-    end
-
-    let(:latency) { 123 }
+        let(:latency) { 123 }
     let(:queue_size) { 50 }
 
     it 'latency and queue_size can be configured' do
       expect {
-        described_class.configure do |config|
+        subject.configure do |config|
           config.latency = latency
           config.queue_size = queue_size
         end
-      }.to change { described_class.new.configuration.latency }.to(latency).and \
-        change { described_class.new.configuration.queues[default_queue_name] }.to(
+      }.to change { subject.configuration.latency }.to(latency).and \
+        change { subject.configuration.queues[default_queue_name] }.to(
           latency: latency,
           queue_size: queue_size
         )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ Spork.prefork do
   require 'rspec/rails'
   require 'database_cleaner'
   require 'pry'
+  require 'timecop'
   require 'mock_redis'
   require 'sidekiq/testing'
 


### PR DESCRIPTION
As we've looked into our needs we came across 2 use cases not covered currently by the gem:

1 - Multiple providers

We are using multiple `Redis` instances to back our application (Sidekiq, Action Cable), and therefore we want to be able to monitor them all. I'd image that this is a pretty common scenario specially for folks running Sidekiq in production as per [their recommendation](https://github.com/sidekiq/sidekiq/wiki/Using-Redis#multiple-redis-instances)

2 - Mark components as `non-critical` for status purpose

There might be certain components that are important but not critical for running the application, that could be reported on without failing the overall app health check. This would give us the benefit of having the reporting when navigating to the check endpoint, but not fail the health check avoiding automatic recovery mechanism to taking down the application (container orchestrator/load balancers)

With those in mind, I've spent some time adding that functionality in. The changes worth mentioning are:

1 - Provider configuration: switch from using **Classes** in favour of using **Instances** to allow multiple of the same provider to be defined - With this also replace `Set` with regular `Array`
2 - Added basic common configuration to all provider for allowing customization of **name** and **critical** and whatever else is common in the future

![image](https://user-images.githubusercontent.com/8523281/231861881-cc6c5345-3bc1-4be7-bef8-3bb3a558f428.png)
