### PR TITLE
Fixed add_custom_provider

### DIFF
--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -35,7 +35,7 @@ module HealthMonitor
         raise ArgumentError.new 'custom provider class must implement HealthMonitor::Providers::Base'
       end
 
-      add_provider(custom_provider_class)
+      add_provider(custom_provider_class.new)
     end
 
     private

--- a/spec/lib/health_monitor/configuration_spec.rb
+++ b/spec/lib/health_monitor/configuration_spec.rb
@@ -55,7 +55,7 @@ describe HealthMonitor::Configuration do
       end
 
       it 'returns CustomProvider class' do
-        expect(subject.add_custom_provider(CustomProvider)).to eq(CustomProvider)
+        expect(subject.add_custom_provider(CustomProvider)).to be_a(CustomProvider)
       end
     end
 


### PR DESCRIPTION
I observed while creating a custom provider that it wasn't getting instantiated as how the default providers were.

This is the fix for that.