### PR TITLE
Adding FileAbsence provider to check that a file remains absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The following services are currently supported:
 * Resque
 * Delayed Job
 * Solr
+* FileAbsence
 
 ## Configuration
 
@@ -317,6 +318,12 @@ Please note that `url` or `connection` can't be used at the same time.
 
 * `url`: the URL used to connect to your Solr instance - must be a string. You can also use `url` to explicitly configure authentication (e.g., `'https://user:pass@example.solr.com:8983/'`)
 * `collection`: An optional parameter used to connect to your specific Solr collection - must be a string. By setting this parameter the code will check the status of this individual collection in your Solr instance instead of just the status of the overall Solr instance
+
+### FileAbsence
+This check allows you to create a file on your server when you would like to force the check to fail.  For example if you are utilizing the health.json as you health check page for your load balancer and would like to force a machine offline.
+
+* `filename`: the file relative to the rails root that must remain absent for the health check to remain passing. For example `public/remove-from-nginx`
+
 
 ### Adding a Custom Provider
 

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -2,7 +2,7 @@
 
 module HealthMonitor
   class Configuration
-    PROVIDERS = %i[cache database delayed_job redis resque sidekiq solr].freeze
+    PROVIDERS = %i[cache database delayed_job file_absence redis resque sidekiq solr].freeze
 
     attr_accessor :basic_auth_credentials,
                   :environment_variables,

--- a/lib/health_monitor/providers/file_absence.rb
+++ b/lib/health_monitor/providers/file_absence.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'health_monitor/providers/base'
+
+module HealthMonitor
+  module Providers
+    class FileAbsenceException < StandardError; end
+
+    class FileAbsence < Base
+      class Configuration < Base::Configuration
+        DEFAULT_FILENAME = nil
+        attr_accessor :filename
+
+        def initialize(provider)
+          super(provider)
+
+          @filename = DEFAULT_FILENAME
+        end
+      end
+
+      def check!
+        return unless File.exist?(configuration.filename)
+
+        raise FileAbsenceException.new("Unwanted file #{configuration.filename} exists!")
+      end
+
+      private
+
+      def configuration_class
+        ::HealthMonitor::Providers::FileAbsence::Configuration
+      end
+    end
+  end
+end

--- a/spec/lib/health_monitor/providers/file_absence_spec.rb
+++ b/spec/lib/health_monitor/providers/file_absence_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe HealthMonitor::Providers::FileAbsence do
+  subject { described_class.new }
+
+  context 'with defaults' do
+    it { expect(subject.configuration.name).to eq('FileAbsence') }
+    it { expect(subject.configuration.filename).to eq(HealthMonitor::Providers::FileAbsence::Configuration::DEFAULT_FILENAME) }
+  end
+
+  describe '#name' do
+    it { expect(subject.name).to eq('FileAbsence') }
+  end
+
+  describe '#check!' do
+    let(:filename) { 'bad-file' }
+
+    before do
+      subject.request = test_request
+      subject.configure do |config|
+        config.filename = filename
+      end
+      allow(File).to receive('exist?').with(filename).and_return(false)
+    end
+
+    context 'with a standard connection' do
+      it 'checks the file' do
+        subject.check!
+        expect(File).to have_received('exist?')
+      end
+
+      it 'succesfully checks' do
+        expect {
+          subject.check!
+        }.not_to raise_error
+      end
+
+      context 'when failing' do
+        before do
+          allow(File).to receive('exist?').with(filename).and_return(true)
+        end
+
+        it 'fails check!' do
+          expect {
+            subject.check!
+          }.to raise_error(HealthMonitor::Providers::FileAbsenceException)
+        end
+
+        it 'checks against the configured solr url' do
+          expect {
+            subject.check!
+          }.to raise_error(HealthMonitor::Providers::FileAbsenceException)
+          expect(File).to have_received('exist?')
+        end
+      end
+    end
+  end
+
+  describe '#configure' do
+    before do
+      subject.configure
+    end
+
+    let(:filename) { 'public/bad-file' }
+
+    it 'filename can be configured' do
+      expect {
+        subject.configure do |config|
+          config.filename = filename
+        end
+      }.to change { subject.configuration.filename }.to(filename)
+    end
+  end
+end


### PR DESCRIPTION
We are utilizing this to manually trigger a health page failure when we want to test that our load balancer is reading the health page correctly