### PR TITLE
Address #connection deprecation in favor of #lease_connection

### DIFF
--- a/lib/health_monitor/providers/database.rb
+++ b/lib/health_monitor/providers/database.rb
@@ -11,7 +11,7 @@ module HealthMonitor
         failed_databases = []
 
         ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |cp|
-          cp.connection.execute('SELECT 1')
+          cp.lease_connection.execute('SELECT 1')
         rescue Exception
           failed_databases << cp.db_config.name
         end


### PR DESCRIPTION
Fixes #129 by addressing the deprecated `#connection` method in favor of the rails 8 supported `#lease_connection` method.