### PR TITLE
Fix compatibility with Rails 7 by conditionally using `lease_connection`

### DIFF
--- a/lib/health_monitor/providers/database.rb
+++ b/lib/health_monitor/providers/database.rb
@@ -11,7 +11,7 @@ module HealthMonitor
         failed_databases = []
 
         ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |cp|
-          if Rails::VERSION::MAJOR >= 8
+          if cp.respond_to? :lease_connection
             cp.lease_connection.execute('SELECT 1')
           else
             cp.connection.execute('SELECT 1')

--- a/lib/health_monitor/providers/database.rb
+++ b/lib/health_monitor/providers/database.rb
@@ -11,7 +11,11 @@ module HealthMonitor
         failed_databases = []
 
         ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |cp|
-          cp.lease_connection.execute('SELECT 1')
+          if Rails::VERSION::MAJOR >= 8
+            cp.lease_connection.execute('SELECT 1')
+          else
+            cp.connection.execute('SELECT 1')
+          end
         rescue Exception
           failed_databases << cp.db_config.name
         end


### PR DESCRIPTION
I've got this error in a Rails 7 app:

`undefined method 'lease_connection' for an instance of ActiveRecord::ConnectionAdapters::ConnectionPool`