### PR TITLE
Add config_name configuration to database provider to check specific database config

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,21 @@ HealthMonitor.configure do |config|
 end
 ```
 
+When you have multiple databases and and want to check each configuration separately you can use following method:
+```ruby
+HealthMonitor.configure do |config|
+  config.no_database # Disable default all databases check
+  config.database.configure do |provider_config|
+    provider_config.config_name = 'primary'
+  end
+  config.database.configure do |provider_config|
+    provider_config.name = 'Secondary'
+    provider_config.config_name = 'secondary'
+    provider_config.critical = false
+  end
+end
+```
+
 ### Provider Configuration
 
 All providers accept a general set of baseline configuration:

--- a/lib/health_monitor/providers/database.rb
+++ b/lib/health_monitor/providers/database.rb
@@ -31,11 +31,7 @@ module HealthMonitor
           next unless check_connection_pool?(cp)
 
           checked = true
-          if cp.respond_to? :lease_connection
-            cp.lease_connection.execute('SELECT 1')
-          else
-            cp.connection.execute('SELECT 1')
-          end
+          check_connection(cp)
         rescue Exception
           failed_databases << cp.db_config.name
         end
@@ -54,6 +50,14 @@ module HealthMonitor
 
       def check_connection_pool?(connection_pool)
         configuration.config_name.nil? || configuration.config_name == connection_pool.db_config.name
+      end
+
+      def check_connection(connection_pool)
+        if connection_pool.respond_to?(:lease_connection)
+          connection_pool.lease_connection.execute('SELECT 1')
+        else
+          connection_pool.connection.execute('SELECT 1')
+        end
       end
     end
   end

--- a/lib/health_monitor/providers/database.rb
+++ b/lib/health_monitor/providers/database.rb
@@ -7,10 +7,30 @@ module HealthMonitor
     class DatabaseException < StandardError; end
 
     class Database < Base
+      class Configuration < Base::Configuration
+        DEFAULT_CONFIG_NAME = nil
+
+        attr_reader :config_name
+
+        def initialize(provider)
+          super
+
+          @config_name = DEFAULT_CONFIG_NAME
+        end
+
+        def config_name=(value)
+          @config_name = value.presence&.to_s
+        end
+      end
+
       def check!
+        checked = false
         failed_databases = []
 
         ActiveRecord::Base.connection_handler.connection_pool_list(:all).each do |cp|
+          next unless check_connection_pool?(cp)
+
+          checked = true
           if cp.respond_to? :lease_connection
             cp.lease_connection.execute('SELECT 1')
           else
@@ -21,8 +41,19 @@ module HealthMonitor
         end
 
         raise "unable to connect to: #{failed_databases.uniq.join(',')}" unless failed_databases.empty?
+        raise "no connections checked with name: #{configuration.config_name}" if configuration.config_name && !checked
       rescue Exception => e
         raise DatabaseException.new(e.message)
+      end
+
+      private
+
+      def configuration_class
+        ::HealthMonitor::Providers::Database::Configuration
+      end
+
+      def check_connection_pool?(connection_pool)
+        configuration.config_name.nil? || configuration.config_name == connection_pool.db_config.name
       end
     end
   end

--- a/spec/lib/health_monitor/providers/database_spec.rb
+++ b/spec/lib/health_monitor/providers/database_spec.rb
@@ -65,6 +65,14 @@ describe HealthMonitor::Providers::Database do
           subject.check!
         }.to raise_error(HealthMonitor::Providers::DatabaseException, 'unable to connect to: database2')
       end
+
+      it 'passes when only first database config is checked' do
+        subject.configure do |config|
+          config.config_name = :database1
+        end
+
+        expect { subject.check! }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/lib/health_monitor/providers/database_spec.rb
+++ b/spec/lib/health_monitor/providers/database_spec.rb
@@ -74,5 +74,14 @@ describe HealthMonitor::Providers::Database do
         expect { subject.check! }.not_to raise_error
       end
     end
+
+    it 'fails when no connection with given config_name is checked' do
+      subject.configure do |config|
+        config.config_name = :not_existing_database_config
+      end
+      expect { subject.check! }.to raise_error(
+        HealthMonitor::Providers::DatabaseException, 'no connections checked with name: not_existing_database_config'
+      )
+    end
   end
 end


### PR DESCRIPTION
Add `config_name` configuration option to database provider. This allow to configure database checks only for specific config.

The default behaviour remains same. But now you can disable existing global check and configure more specific checks if needed.

Related issue #102. It does not resolve all issues mentioned in the issue comments, but it makes possible to check different database configs separately.