### PR TITLE
Remove expired keys from the Redis

### DIFF
--- a/lib/health_monitor/providers/cache.rb
+++ b/lib/health_monitor/providers/cache.rb
@@ -7,10 +7,12 @@ module HealthMonitor
     class CacheException < StandardError; end
 
     class Cache < Base
+      EXPIRED_TIME_SECONDS = 3
+
       def check!
         time = Time.now.to_formatted_s(:rfc2822)
 
-        Rails.cache.write(key, time)
+        Rails.cache.write(key, time, expires_in: EXPIRED_TIME_SECONDS)
         fetched = Rails.cache.read(key)
 
         raise "different values (now: #{time}, fetched: #{fetched})" if fetched != time

--- a/lib/health_monitor/providers/redis.rb
+++ b/lib/health_monitor/providers/redis.rb
@@ -9,6 +9,8 @@ module HealthMonitor
     class RedisException < StandardError; end
 
     class Redis < Base
+      EXPIRED_TIME_SECONDS = 3
+
       class Configuration < Base::Configuration
         DEFAULT_URL = nil
 
@@ -45,7 +47,7 @@ module HealthMonitor
       def check_values!
         time = Time.now.to_formatted_s(:rfc2822)
 
-        redis.with { |conn| conn.set(key, time) }
+        redis.with { |conn| conn.set(key, time, ex: EXPIRED_TIME_SECONDS) }
         fetched = redis.with { |conn| conn.get(key) }
 
         raise "different values (now: #{time}, fetched: #{fetched})" if fetched != time

--- a/spec/lib/health_monitor/providers/cache_spec.rb
+++ b/spec/lib/health_monitor/providers/cache_spec.rb
@@ -14,7 +14,20 @@ describe HealthMonitor::Providers::Cache do
 
     before { subject.request = test_request }
 
-    it 'succesfully checks' do
+    context 'when value will put in the Redis' do
+      it 'value has been removed' do
+        redis_key = subject.send(:key)
+        subject.check!
+
+        expect(Rails.cache.read(redis_key)).to be_present
+
+        travel_to(4.seconds.since)
+
+        expect(Rails.cache.read(redis_key)).to be_nil
+      end
+    end
+
+    it 'successfully checks' do
       expect {
         subject
       }.not_to raise_error

--- a/spec/lib/health_monitor/providers/cache_spec.rb
+++ b/spec/lib/health_monitor/providers/cache_spec.rb
@@ -21,7 +21,7 @@ describe HealthMonitor::Providers::Cache do
 
         expect(Rails.cache.read(redis_key)).to be_present
 
-        travel_to(4.seconds.since)
+        travel_to((described_class::EXPIRED_TIME_SECONDS + 1).seconds.since)
 
         expect(Rails.cache.read(redis_key)).to be_nil
       end

--- a/spec/lib/health_monitor/providers/redis_spec.rb
+++ b/spec/lib/health_monitor/providers/redis_spec.rb
@@ -24,7 +24,9 @@ describe HealthMonitor::Providers::Redis do
         end
       end
 
-      it 'succesfully checks' do
+      it_behaves_like 'expiring value in the redis'
+
+      it 'successfully checks' do
         expect {
           subject.check!
         }.not_to raise_error
@@ -50,7 +52,9 @@ describe HealthMonitor::Providers::Redis do
         end
       end
 
-      it 'succesfully checks' do
+      it_behaves_like 'expiring value in the redis'
+
+      it 'successfully checks' do
         expect {
           subject.check!
         }.not_to raise_error
@@ -91,7 +95,9 @@ describe HealthMonitor::Providers::Redis do
         end
       end
 
-      it 'succesfully checks' do
+      it_behaves_like 'expiring value in the redis'
+
+      it 'successfully checks' do
         expect {
           subject.check!
         }.not_to raise_error
@@ -117,7 +123,9 @@ describe HealthMonitor::Providers::Redis do
         end
       end
 
-      it 'succesfully checks' do
+      it_behaves_like 'expiring value in the redis'
+
+      it 'successfully checks' do
         expect {
           subject.check!
         }.not_to raise_error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ Spork.prefork do
   RSpec.configure do |config|
     config.mock_with :rspec
 
+    config.include ActiveSupport::Testing::TimeHelpers
     config.include Capybara::DSL
 
     config.before(:suite) do

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+shared_examples 'expiring value in the redis' do
+  context 'when a value being set' do
+    let(:redis_key) { 'health:0.0.0.0' }
+
+    it 'removes this one in the future' do
+      subject.check!
+
+      expect(subject.send(:redis).with { |r| r.get(redis_key) }).to be_present
+
+      travel_to(4.seconds.since)
+
+      expect(subject.send(:redis).with { |r| r.get(redis_key) }).to be_nil
+    end
+  end
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -9,7 +9,7 @@ shared_examples 'expiring value in the redis' do
 
       expect(subject.send(:redis).with { |r| r.get(redis_key) }).to be_present
 
-      travel_to(4.seconds.since)
+      travel_to((described_class::EXPIRED_TIME_SECONDS + 1).seconds.since)
 
       expect(subject.send(:redis).with { |r| r.get(redis_key) }).to be_nil
     end


### PR DESCRIPTION
Changed: expired keys has being removed from the Redis
#137 

@lbeder 