### PR TITLE
Add baseline config interface for custom providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,18 +348,33 @@ To add a custom provider, you'd need to:
 * Implement the `HealthMonitor::Providers::Base` class and its `check!` method (a check is considered as failed if it raises an exception):
 
 ```ruby
-class CustomProvider < HealthMonitor::Providers::Base
+class CustomFoo < HealthMonitor::Providers::Base
+  def check!
+    raise 'Oh oh!'
+  end
+end
+
+class CustomBar < HealthMonitor::Providers::Base
   def check!
     raise 'Oh oh!'
   end
 end
 ```
 
-* Add its class to the configuration:
+* Add it's class to the configuration with `init_custom_providers`, then configure the same as in-house providers.
 
 ```ruby
 HealthMonitor.configure do |config|
-  config.add_custom_provider(CustomProvider)
+  config.init_custom_providers([CustomFoo, CustomBar])
+
+  # Setting values for baseline configuration
+  config.custom_foo.configure do |custom_foo_config|
+    custom_foo_config.name = "Foo API"
+    custom_foo_config.critical = true
+  end
+
+  # Assuming defaults for baseline configuration
+  config.custom_bar 
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ class CustomBar < HealthMonitor::Providers::Base
 end
 ```
 
-* Add it's class to the configuration with `init_custom_providers`, then configure the same as in-house providers.
+* Add its class to the configuration with `init_custom_providers`, then configure the same as in-house providers.
 
 ```ruby
 HealthMonitor.configure do |config|

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -30,15 +30,24 @@ module HealthMonitor
       end
     end
 
-    def add_custom_provider(custom_provider_class)
-      unless custom_provider_class < HealthMonitor::Providers::Base
-        raise ArgumentError.new 'custom provider class must implement HealthMonitor::Providers::Base'
+    # TODO: update README.md
+    def init_custom_providers(provider_names)
+      provider_names.each do |provider_name|
+        add_custom_provider(provider_name)
       end
-
-      add_provider(custom_provider_class.new)
     end
 
     private
+
+    def add_custom_provider(provider_name)
+      unless provider_name < HealthMonitor::Providers::Base
+        raise ArgumentError.new "custom provider class #{provider_name} must implement HealthMonitor::Providers::Base"
+      end
+
+      self.class.define_method(provider_name.to_s.underscore) do |&_block|
+        add_provider("HealthMonitor::Providers::#{provider_name}".constantize.new)
+      end
+    end
 
     def add_provider(provider)
       (@providers ||= []) << provider

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -30,7 +30,6 @@ module HealthMonitor
       end
     end
 
-    # TODO: update README.md
     def init_custom_providers(provider_names)
       provider_names.each do |provider_name|
         add_custom_provider(provider_name)

--- a/spec/lib/health_monitor/configuration_spec.rb
+++ b/spec/lib/health_monitor/configuration_spec.rb
@@ -46,7 +46,7 @@ describe HealthMonitor::Configuration do
 
   # TODO: consider DRYing with in-house provider test cases
   describe 'custom providers' do
-    CUSTOM_PROVIDERS = [Foo, BazBuz]
+    CUSTOM_PROVIDERS = [Foo, BazBuz].freeze
 
     CUSTOM_PROVIDERS.each do |provider_name|
       before do
@@ -78,12 +78,12 @@ describe HealthMonitor::Configuration do
     end
 
     context 'when inherits' do
-     let(:provider_name) { Foo }
+      let(:provider_name) { Foo }
 
       it 'accepts' do
         expect {
           subject.init_custom_providers([provider_name])
-        }.to_not raise_error(ArgumentError)
+        }.not_to raise_error(ArgumentError)
       end
     end
 


### PR DESCRIPTION
Added: baseline config interface for custom providers cc @lbeder 

This will let us do things like setting a custom provider as critical
``` ruby
  config.init_custom_providers([CustomFoo])

  # Setting values for baseline configuration
  config.custom_foo.configure do |custom_foo_config|
    custom_foo_config.name = "Foo API"
    custom_foo_config.critical = true
  end
```