### PR TITLE
Add show response times for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,16 @@ end
 
 This will make the page to be served in the `/status` endpoint for instance (from where the engine was mounted).
 
+### Showing response time of checks
+
+```ruby
+HealthMonitor.configure do |config|
+  config.response_threshold = 0.8
+end
+```
+
+By default, this setting is disable. You need is to enable to write a `Float` value in the setting like a threshold. After this, each provider will measure the theirs response time. And if response time exceeded the threshold - you will see that by the `/check` endpoint on the view.
+
 ### Monitoring Script
 
 A Nagios/Shinken/Icinga/Icinga2 plugin is available in `extra` directory.

--- a/README.md
+++ b/README.md
@@ -430,15 +430,14 @@ end
 
 This will make the page to be served in the `/status` endpoint for instance (from where the engine was mounted).
 
-### Showing response time of checks
+### Showing Response Times of Checks
 
 ```ruby
 HealthMonitor.configure do |config|
   config.response_threshold = 0.8
 end
 ```
-
-By default, this setting is disable. You need is to enable to write a `Float` value in the setting like a threshold. After this, each provider will measure the theirs response time. And if response time exceeded the threshold - you will see that by the `/check` endpoint on the view.
+By default, this setting is disabled. Enable it and enter a floating‑point threshold value. Once enabled, each provider logs its response time; if a provider’s response time exceeds the threshold, the issue will be visible via the `/check` endpoint.
 
 ### Monitoring Script
 

--- a/app/views/health_monitor/health/check.html.erb
+++ b/app/views/health_monitor/health/check.html.erb
@@ -116,6 +116,17 @@
         color: rgb(71 85 105);
       }
 
+      .response {
+        font-weight: 800;
+      }
+
+      .bordering {
+        border: solid 1px red;
+        width: auto;
+        margin: 0.5em;
+        padding: 0.5em;
+      }
+
       dt {
         min-width: 10vw;
         font-size: 0.875rem;
@@ -148,7 +159,7 @@
         <div class="border">
           <dl>
             <% @statuses[:results].each_with_index do |status, index| %>
-              <div class="<%= index.odd? ? 'bg-gray' : 'bg-white' %> item">
+              <div class="<%= index.odd? ? 'bg-gray' : 'bg-white' %> <%= 'bordering' if status[:slow_response] %> item">
                 <dt class="name">
                   <%= status[:name] %>
                 </dt>
@@ -157,6 +168,11 @@
                   <div class="state <%= 'red' if status[:status].downcase == 'error' %> font-bold">
                     <%= status[:status] %>
                   </div>
+                  <% if HealthMonitor.configuration.response_threshold %>
+                    <div class="response <%= 'red' if status[:slow_response] %> font-bold">
+                      <%= status[:response_time] %>
+                    </div>
+                  <% end %>
                   <% if !status[:message].empty? %>
                     <div class="message"><%= status[:message] %></div>
                   <% end %>

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -8,7 +8,8 @@ module HealthMonitor
                   :environment_variables,
                   :error_callback,
                   :hide_footer,
-                  :path
+                  :path,
+                  :response_threshold
     attr_reader :providers
 
     def initialize

--- a/spec/features/health_monitor/health_monitor_spec.rb
+++ b/spec/features/health_monitor/health_monitor_spec.rb
@@ -28,6 +28,27 @@ describe 'Health Monitor' do
     end
   end
 
+  context 'when response threshold is configured' do
+    let(:response_threshold) { 0.5 }
+
+    before do
+      HealthMonitor.configure do |config|
+        config.response_threshold = response_threshold
+      end
+
+      allow(HealthMonitor).to receive(:measure_response_time).and_return(response_threshold)
+    end
+
+    it 'renders html' do
+      visit '/check'
+
+      expect(page).to have_css('h2', count: 1)
+      expect(page).to have_css('h2', text: 'Services')
+      expect(page).to have_css('.services dt.name', text: 'Database')
+      expect(page).to have_css('.services div.response', text: response_threshold)
+    end
+  end
+
   context 'when env variables are configured' do
     let(:environment_variables) { { build_number: '12', git_sha: 'example_sha' } }
 


### PR DESCRIPTION
Added: ability show response times for providers optionally

- [x] Write docs...

#108 

```rb
  # Setting target option
  HealthMonitor. do |config|
    config.response_threshold = 0.8
  end
```

Below the variant of view with failed provider

![image](https://github.com/user-attachments/assets/df52d7bc-7828-4b47-af66-dd12cbd7d365)

cc @lbeder
